### PR TITLE
ubuntu1004: Support apt-get from derived image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,5 +213,6 @@ workflows:
             - centos5
             - centos6
             - centos7
+            - ubuntu1004
             - ubuntu1604
             - ubuntu1804

--- a/ubuntu1004/Dockerfile
+++ b/ubuntu1004/Dockerfile
@@ -55,7 +55,8 @@ RUN \
   #
   # cleanup
   #
-  rm -rf /var/lib/apt/lists/*
+  rm -rf /var/lib/apt/lists/* && \
+  mkdir /var/lib/apt/lists/partial
 
 ENV AS=/usr/bin/as \
     AR=/usr/bin/ar \


### PR DESCRIPTION
This commit fixes the following error when creating derived image
that try to update and/or install packages:

```
$ apt-get update
Lists directory /var/lib/apt/lists/partial is missing
```