### PR TITLE
Add OpenSSH to all images to support source checkout on CircleCI

### DIFF
--- a/centos5/Dockerfile
+++ b/centos5/Dockerfile
@@ -19,6 +19,7 @@ COPY build_scripts /build_scripts
 
 COPY \
   imagefiles/build-and-install-cmake.sh \
+  imagefiles/build-and-install-openssh.sh \
   imagefiles/install-gosu-binary.sh \
   imagefiles/install-ninja-binary.sh \
   imagefiles/install-entrypoint.sh \

--- a/centos5/build_scripts/build.sh
+++ b/centos5/build_scripts/build.sh
@@ -188,6 +188,7 @@ ln -s $($PY36_BIN/python -c 'import certifi; print(certifi.where())') \
 export SSL_CERT_FILE=/opt/_internal/certs.pem
 
 # [centosbuild]
+/imagefiles/build-and-install-openssh.sh
 /imagefiles/build-and-install-cmake.sh
 # [/centosbuild]
 

--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -34,6 +34,7 @@ RUN yum update -y && \
    file \
    gettext \
    make \
+   openssh-clients \
    openssl-devel \
    patch \
    perl \

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -34,6 +34,7 @@ RUN yum update -y && \
    file \
    gettext \
    make \
+   openssh-clients \
    openssl-devel \
    patch \
    perl \

--- a/imagefiles/build-and-install-openssh.sh
+++ b/imagefiles/build-and-install-openssh.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ex
+
+OPENSSH_ROOT=V_7_6_P1
+
+cd /usr/src
+curl -LO https://github.com/openssh/openssh-portable/archive/${OPENSSH_ROOT}.tar.gz
+tar -xvf ${OPENSSH_ROOT}.tar.gz
+rm -f ${OPENSSH_ROOT}.tar.gz
+
+OPENSSH_SRC_DIR=openssh-portable-${OPENSSH_ROOT}
+cd ${OPENSSH_SRC_DIR}
+
+autoreconf
+
+./configure --prefix=/usr/local
+
+make -j1 install
+
+cd /usr/src
+rm -rf ${OPENSSH_SRC_DIR}

--- a/ubuntu1004/Dockerfile
+++ b/ubuntu1004/Dockerfile
@@ -12,6 +12,7 @@ COPY \
   imagefiles/build-and-install-git.sh \
   imagefiles/install-gosu-binary.sh \
   imagefiles/build-and-install-openssl.sh \
+  imagefiles/build-and-install-openssh.sh \
   imagefiles/build-and-install-python.sh \
   imagefiles/install-cmake-binary.sh \
   imagefiles/install-entrypoint.sh \
@@ -27,6 +28,7 @@ RUN \
   apt-get -y upgrade && \
   apt-get update && \
   apt-get install -y \
+    autoconf \
     build-essential \
     curl \
     unzip \
@@ -45,6 +47,7 @@ RUN \
   #
   /imagefiles/build-and-install-openssl.sh && \
   /imagefiles/build-and-install-curl.sh && \
+  /imagefiles/build-and-install-openssh.sh && \
   /imagefiles/build-and-install-git.sh && \
   /imagefiles/build-and-install-python.sh && \
   /imagefiles/install-cmake-binary.sh && \

--- a/ubuntu1004/Dockerfile
+++ b/ubuntu1004/Dockerfile
@@ -2,8 +2,6 @@ FROM ubuntu:10.04
 
 ENV DEFAULT_DOCKCROSS_IMAGE=dockbuild/ubuntu1004
 
-ARG DEBIAN_FRONTEND=noninteractive
-
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2
 ARG NINJA_VERSION=1.8.2
@@ -20,6 +18,8 @@ COPY \
   imagefiles/install-ninja-binary.sh \
   imagefiles/utils.sh \
   /imagefiles/
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
   sed -i "s/archive.ubuntu.com/old-releases.ubuntu.com/" /etc/apt/sources.list && \

--- a/ubuntu1604/Dockerfile
+++ b/ubuntu1604/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
     build-essential \
     curl \
     gosu \
+    openssh-client \
     unzip \
   && \
   # Needed to build Git from source

--- a/ubuntu1604/Dockerfile
+++ b/ubuntu1604/Dockerfile
@@ -18,6 +18,8 @@ COPY \
   imagefiles/install-entrypoint.sh \
   /imagefiles/
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get update && \

--- a/ubuntu1804/Dockerfile
+++ b/ubuntu1804/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update && \
     build-essential \
     curl \
     gosu \
+    openssh-client \
     unzip \
   && \
   # Needed to build Git from source

--- a/ubuntu1804/Dockerfile
+++ b/ubuntu1804/Dockerfile
@@ -18,6 +18,8 @@ COPY \
   imagefiles/install-entrypoint.sh \
   /imagefiles/
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
   apt-get -y upgrade && \
   apt-get update && \


### PR DESCRIPTION
This should help address the following:

Either git or ssh (required by git to clone through SSH) is not
installed in the image. Falling back to CircleCI's native git client
but the behavior may be different from official git. If this is an
issue, please use an image that has official git and ssh installed.