### PR TITLE
Fix Centos warnings by using en_US.UTF-8 instead of C.UTF-8

### DIFF
--- a/centos5-devtoolset2-gcc4/Dockerfile
+++ b/centos5-devtoolset2-gcc4/Dockerfile
@@ -7,7 +7,12 @@ ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     FC=/opt/rh/devtoolset-2/root/usr/bin/gfortran \
     PATH=/opt/rh/devtoolset-2/root/usr/bin${PATH:+:${PATH}} \
     LD_LIBRARY_PATH=/opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/usr/local/lib64:/usr/local/lib \
-    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+    PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
+    # http://bugs.python.org/issue19846
+    # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
+    # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
+    LANG=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG NINJA_VERSION=1.8.2

--- a/centos6-devtoolset2-gcc4/Dockerfile
+++ b/centos6-devtoolset2-gcc4/Dockerfile
@@ -8,7 +8,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     PATH=/opt/rh/devtoolset-2/root/usr/bin${PATH:+:${PATH}} \
     # http://bugs.python.org/issue19846
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-    LANG=C.UTF-8
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
+    # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
+    LANG=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2

--- a/centos7-devtoolset4-gcc5/Dockerfile
+++ b/centos7-devtoolset4-gcc5/Dockerfile
@@ -7,7 +7,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=dockbuild/centos7 \
     PATH=/opt/rh/devtoolset-4/root/usr/bin${PATH:+:${PATH}} \
     # http://bugs.python.org/issue19846
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-    LANG=C.UTF-8
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
+    # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
+    LANG=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2

--- a/ubuntu1004-gcc4/Dockerfile
+++ b/ubuntu1004-gcc4/Dockerfile
@@ -1,7 +1,12 @@
 FROM ubuntu:10.04
 
 ARG IMAGE
-ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE}
+ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
+    # http://bugs.python.org/issue19846
+    # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
+    # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
+    LANG=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2

--- a/ubuntu1604-gcc5/Dockerfile
+++ b/ubuntu1604-gcc5/Dockerfile
@@ -4,6 +4,8 @@ ARG IMAGE
 ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     # http://bugs.python.org/issue19846
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
+    # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
     LANG=C.UTF-8
 
 ARG CMAKE_VERSION=3.10.2

--- a/ubuntu1804-gcc7/Dockerfile
+++ b/ubuntu1804-gcc7/Dockerfile
@@ -4,7 +4,9 @@ ARG IMAGE
 ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     # http://bugs.python.org/issue19846
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
-    LANG=C.UTF-8
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
+    # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
+    LANG=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2


### PR DESCRIPTION
C.UTF-8 is not supported on all systems. For sake of consistency, we
set en_US.UTF-8 in all images.

References:
* https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
* https://github.com/commercialhaskell/stack/issues/856

Warnings addressed by this commit are like the following:

svn: warning: cannot set LC_CTYPE locale
svn: warning: environment variable LANG is C.UTF-8
svn: warning: please check that your locale name is correct