### PR TITLE
Fix more lang warnings setting LC_ALL and LANGUAGE env. variables

### DIFF
--- a/centos5-devtoolset2-gcc4/Dockerfile
+++ b/centos5-devtoolset2-gcc4/Dockerfile
@@ -12,7 +12,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
     # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
-    LANG=en_US.UTF-8
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG NINJA_VERSION=1.8.2

--- a/centos6-devtoolset2-gcc4/Dockerfile
+++ b/centos6-devtoolset2-gcc4/Dockerfile
@@ -10,7 +10,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
     # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
-    LANG=en_US.UTF-8
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2

--- a/centos7-devtoolset4-gcc5/Dockerfile
+++ b/centos7-devtoolset4-gcc5/Dockerfile
@@ -9,7 +9,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=dockbuild/centos7 \
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
     # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
-    LANG=en_US.UTF-8
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2

--- a/ubuntu1004-gcc4/Dockerfile
+++ b/ubuntu1004-gcc4/Dockerfile
@@ -6,7 +6,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
     # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
-    LANG=en_US.UTF-8
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2

--- a/ubuntu1604-gcc5/Dockerfile
+++ b/ubuntu1604-gcc5/Dockerfile
@@ -6,7 +6,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
     # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
-    LANG=C.UTF-8
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2

--- a/ubuntu1804-gcc7/Dockerfile
+++ b/ubuntu1804-gcc7/Dockerfile
@@ -6,7 +6,9 @@ ENV DEFAULT_DOCKCROSS_IMAGE=${IMAGE} \
     # > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
     # https://sourceware.org/bugzilla/show_bug.cgi?id=17318#c4
     # > set en_US.UTF-8 instead of C.UTF-8 because the former is not supported on all systems.
-    LANG=en_US.UTF-8
+    LANG=en_US.UTF-8 \
+    LC_ALL=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8
 
 ARG CMAKE_VERSION=3.10.2
 ARG GIT_VERSION=2.16.2


### PR DESCRIPTION
This should help fix warnings like this one:

perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LANG = "en_US.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory