### PR TITLE
Misc. fixes

### DIFF
--- a/centos5-devtoolset2-gcc4/Dockerfile
+++ b/centos5-devtoolset2-gcc4/Dockerfile
@@ -42,6 +42,9 @@ RUN \
   /imagefiles/install-gosu-binary.sh && \
   /imagefiles/install-ninja-binary.sh && \
   /imagefiles/install-entrypoint.sh && \
+  # Remove sudo provided by "devtoolset-2" since it doesn't work with
+  # our sudo wrapper calling gosu.
+  rm -f /opt/rh/devtoolset-2/root/usr/bin/sudo && \
   rm -rf /imagefiles
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem

--- a/imagefiles/install-entrypoint.sh
+++ b/imagefiles/install-entrypoint.sh
@@ -17,8 +17,10 @@ mkdir -p /dockcross
 
 cd /dockcross
 
+DOCKCROSS_GIT_SHA=9966e1aed7c6dba168a1ee90efb430de730914b3
+
 for helper_script in dockcross sudo.sh entrypoint.sh; do
-  url="https://raw.githubusercontent.com/dockcross/dockcross/master/imagefiles/$helper_script"
+  url="https://raw.githubusercontent.com/dockcross/dockcross/${DOCKCROSS_GIT_SHA}/imagefiles/$helper_script"
   echo "Downloading $url"
   curl -# -LO $url
 done

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -13,20 +13,27 @@ if ! command -v gpg &> /dev/null; then
 fi
 
 GOSU_VERSION=1.10
+dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')";
+url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"
+url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"
+
+# download and verify the signature
+export GNUPGHOME="$(mktemp -d)"
 
 gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 
-url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"
 echo "Downloading $url"
 curl -o /usr/local/bin/gosu -# -SL $url
 
-url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64.asc"
-echo "Downloading $url"
-curl -o /usr/local/bin/gosu.asc -# -SL $url
+echo "Downloading $url_key"
+curl -o /usr/local/bin/gosu.asc -# -SL $url_key
 
 gpg --verify /usr/local/bin/gosu.asc
 
-rm /usr/local/bin/gosu.asc
-rm -r /root/.gnupg/ || echo "/root/.gnupg/ not found"
+# cleanup
+rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
 
 chmod +x /usr/local/bin/gosu
+
+# verify that the binary works
+gosu nobody true

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -13,7 +13,7 @@ if ! command -v gpg &> /dev/null; then
 fi
 
 GOSU_VERSION=1.10
-dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')";
+dpkgArch=$(if test $(uname -m) = "x86_64"; then echo amd64; else echo i386; fi)
 url="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}"
 url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${dpkgArch}.asc"
 

--- a/ubuntu1004-gcc4/Dockerfile
+++ b/ubuntu1004-gcc4/Dockerfile
@@ -33,6 +33,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN \
   sed -i "s/archive.ubuntu.com/old-releases.ubuntu.com/" /etc/apt/sources.list && \
   apt-get update && \
+  \
+  (LANG=C LANGUAGE=C LC_ALL=C apt-get install -y locales) && \
+  locale-gen ${LANG%.*} ${LANG} && \
+  \
   apt-get -y upgrade && \
   apt-get update && \
   apt-get install -y \

--- a/ubuntu1604-gcc5/Dockerfile
+++ b/ubuntu1604-gcc5/Dockerfile
@@ -25,7 +25,12 @@ COPY \
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+RUN \
+  apt-get update && \
+  \
+  (LANG=C LANGUAGE=C LC_ALL=C apt-get install -y locales) && \
+  locale-gen ${LANG%.*} ${LANG} && \
+  \
   apt-get -y upgrade && \
   apt-get update && \
   apt-get install -y \

--- a/ubuntu1804-gcc7/Dockerfile
+++ b/ubuntu1804-gcc7/Dockerfile
@@ -25,7 +25,12 @@ COPY \
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && \
+RUN \
+  apt-get update && \
+  \
+  (LANG=C LANGUAGE=C LC_ALL=C apt-get install -y locales) && \
+  locale-gen ${LANG%.*} ${LANG} && \
+  \
   apt-get -y upgrade && \
   apt-get update && \
   apt-get install -y \


### PR DESCRIPTION
* ubuntu: Install "locale" package and generate UTF-8 locals 
* install-entrypoints: Update dockcross version. Fixes #30 
* install-entrypoints: Update dockcross version. 
* install-gosu-binary: Add support for 32/64 arch, use temporary GNUPGHOME 
* centos5-devtoolset2-gcc4: Fix use of "sudo" removing version provided by devtoolset-2