### PR TITLE
Tweak install scripts to match version using in dockcross

### DIFF
--- a/imagefiles/build-and-install-git.sh
+++ b/imagefiles/build-and-install-git.sh
@@ -31,7 +31,7 @@ tar xvzf git-${GIT_VERSION}.tar.gz
 rm -f git-${GIT_VERSION}.tar.gz
 
 pushd git-${GIT_VERSION}
-./configure --prefix=/usr/local
+./configure --prefix=/usr/local --with-curl
 make
 make install
 popd

--- a/imagefiles/build-and-install-openssl.sh
+++ b/imagefiles/build-and-install-openssl.sh
@@ -1,6 +1,43 @@
 #!/bin/bash
+#
+# Configure, build and install OpenSSL
+#
+# Usage:
+#
+#  build-and-install-openssl.sh [-32]
+#
+# Options:
+#
+#  -32              Build OpenSSL as a 32-bit library
+#
+# Notes:
+#
+#  * build directory is /usr/src/openssl-$OPENSSL_VERSION
+#
+#  * install directory is /usr
+#
+#  * after installation, build directory and archive are removed
+#
 
 set -ex
+set -o pipefail
+
+WRAPPER=""
+CONFIG_FLAG=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -32)
+      WRAPPER="linux32"
+      CONFIG_FLAG="-m32"
+      ;;
+    *)
+      echo "Usage: Usage: ${0##*/} [-32]"
+      exit 1
+      ;;
+  esac
+  shift
+done
 
 MY_DIR=$(dirname "${BASH_SOURCE[0]}")
 source $MY_DIR/utils.sh
@@ -21,9 +58,9 @@ OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
 OPENSSL_DOWNLOAD_URL=ftp://ftp.openssl.org/source
 
 function do_openssl_build {
-    ./config no-ssl2 no-shared -fPIC --prefix=/usr/local/ssl > /dev/null
-    make > /dev/null
-    make install_sw > /dev/null
+    ${WRAPPER} ./config no-ssl2 no-shared -fPIC $CONFIG_FLAG --prefix=/usr/local/ssl > /dev/null
+    ${WRAPPER} make > /dev/null
+    ${WRAPPER} make install_sw > /dev/null
 }
 
 function build_openssl {
@@ -38,6 +75,8 @@ function build_openssl {
     tar -xzf ${openssl_fname}.tar.gz
     (cd ${openssl_fname} && do_openssl_build)
     rm -rf ${openssl_fname} ${openssl_fname}.tar.gz
+    # Cleanup install tree
+    rm -rf /usr/ssl/man
 }
 
 cd /usr/src

--- a/imagefiles/install-cmake-binary.sh
+++ b/imagefiles/install-cmake-binary.sh
@@ -20,20 +20,18 @@ fi
 cd /usr/src
 
 CMAKE_VERSION_XY=$(echo ${CMAKE_VERSION} | sed -r 's/\.[0-9]+(\-rc[0-9])?$//')
+CMAKE_ROOT=cmake-${CMAKE_VERSION}-Linux-x86_64
 
-url=https://cmake.org/files/v${CMAKE_VERSION_XY}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+url=https://cmake.org/files/v${CMAKE_VERSION_XY}/${CMAKE_ROOT}.tar.gz
 echo "Downloading $url"
 curl -# -LO $url
 
-tar -xzvf cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
-rm -f cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz
+tar -xzvf ${CMAKE_ROOT}.tar.gz
+rm -f ${CMAKE_ROOT}.tar.gz
 
-cd cmake-${CMAKE_VERSION}-Linux-x86_64
+cd ${CMAKE_ROOT}
 
 rm -rf doc man
 rm -rf bin/cmake-gui
 
-ln -s $(pwd)/bin/cmake /usr/local/bin/cmake
-ln -s $(pwd)/bin/ctest /usr/local/bin/ctest
-ln -s $(pwd)/bin/cpack /usr/local/bin/cpack
-ln -s $(pwd)/bin/ccmake /usr/local/bin/ccmake
+find . -type f -exec install -D "{}" "/usr/{}" \;


### PR DESCRIPTION
* instead of using symlinks, explicitly install cmake in /usr
* update cmake and openssl scripts to support -m32 parameter