### PR TITLE
Tweak install scripts to match version using in dockcross

### DIFF
--- a/imagefiles/build-and-install-cmake.sh
+++ b/imagefiles/build-and-install-cmake.sh
@@ -29,35 +29,33 @@ fi
 
 cd /usr/src
 
-git clone git://cmake.org/cmake.git CMake
-
-(cd CMake && git checkout v$CMAKE_VERSION)
+git clone git://cmake.org/cmake.git CMake -b v$CMAKE_VERSION --depth 1
 
 mkdir /usr/src/CMake-build
 cd /usr/src/CMake-build
 
 ${WRAPPER} /usr/src/CMake/bootstrap \
-  --parallel=$(grep -c processor /proc/cpuinfo) \
-  --prefix=/usr/src/CMake-$CMAKE_VERSION
+  --parallel=$(grep -c processor /proc/cpuinfo)
 ${WRAPPER} make -j$(grep -c processor /proc/cpuinfo)
 
-${WRAPPER} ./bin/cmake \
+mkdir /usr/src/CMake-ssl-build
+cd /usr/src/CMake-ssl-build
+
+${WRAPPER} /usr/src/CMake-build/bin/cmake \
   -DCMAKE_BUILD_TYPE:STRING=Release \
   -DBUILD_TESTING:BOOL=OFF \
+  -DCMAKE_INSTALL_PREFIX:PATH=/usr/src/cmake-$CMAKE_VERSION \
   -DCMAKE_USE_OPENSSL:BOOL=ON \
   -DOPENSSL_ROOT_DIR:PATH=/usr/local/ssl \
-  .
+  ../CMake
 ${WRAPPER} make -j$(grep -c processor /proc/cpuinfo) install
 
 # Cleanup install tree
-cd /usr/src/CMake-$CMAKE_VERSION
+cd /usr/src/cmake-$CMAKE_VERSION
 rm -rf doc man
 
 # Install files
 find . -type f -exec install -D "{}" "/usr/{}" \;
-
-# Test
-ctest -R CMake.FileDownload
 
 # Write test script
 cat <<EOF > cmake-test-https-download.cmake
@@ -81,5 +79,5 @@ EOF
 # Execute test script
 cmake -P cmake-test-https-download.cmake
 
-# Remove source and build tree
+# Remove source and build trees
 rm -rf /usr/src/CMake*

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -ex
+set -o pipefail
 
 if ! command -v curl &> /dev/null; then
 	echo >&2 'error: "curl" not found!'
@@ -20,7 +21,9 @@ url_key="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-$
 # download and verify the signature
 export GNUPGHOME="$(mktemp -d)"
 
-gpg --keyserver pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+gpg --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 || \
+gpg --keyserver hkp://pgp.key-server.io:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 || \
+gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 
 echo "Downloading $url"
 curl -o /usr/local/bin/gosu -# -SL $url


### PR DESCRIPTION
* fix intermittent CMake build error using two separate build directories.
  One for bootstrap CMake, and one for CMake with SSL support.

* improve reliability of install-gosu-binary.sh script attempting to download
  GPG key from  multiple server.