### PR TITLE
UpdateFromUpstream: imagefiles 2019-03-02 (b5a13fa4)

### DIFF
--- a/centos5-devtoolset2-gcc4/build_scripts/build.sh
+++ b/centos5-devtoolset2-gcc4/build_scripts/build.sh
@@ -9,10 +9,9 @@ CPYTHON_VERSIONS="3.6.4"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive
-OPENSSL_ROOT=openssl-1.0.2o
-# Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
-# Matches hash at https://github.com/Homebrew/homebrew-core/blob/1766321103d9780f6e38d3ac7681b8fa42cdca86/Formula/openssl.rb#L11
-OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
+OPENSSL_ROOT=openssl-1.0.2r
+# Get OPENSSL_HASH from https://www.openssl.org/source/
+OPENSSL_HASH=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
 EPEL_RPM_HASH=0dcc89f9bf67a2a515bad64569b7a9615edc5e018f676a578d5fd0f17d3c81d4
 DEVTOOLS_HASH=a8ebeb4bed624700f727179e6ef771dafe47651131a00a78b342251415646acc
 # Update to slightly newer, verified Git commit:

--- a/imagefiles/build-and-install-curl.sh
+++ b/imagefiles/build-and-install-curl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/imagefiles/build-and-install-git.sh
+++ b/imagefiles/build-and-install-git.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 

--- a/imagefiles/build-and-install-openssh.sh
+++ b/imagefiles/build-and-install-openssh.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 
-OPENSSH_ROOT=V_7_6_P1
+OPENSSH_ROOT=V_7_9_P1
 
 cd /usr/src
 curl -LO https://github.com/openssh/openssh-portable/archive/${OPENSSH_ROOT}.tar.gz
@@ -14,7 +14,7 @@ cd ${OPENSSH_SRC_DIR}
 
 autoreconf
 
-./configure --prefix=/usr/local
+./configure --with-ssl-dir=/usr/local/ssl --prefix=/usr/local
 
 make -j1 install
 

--- a/imagefiles/build-and-install-openssl.sh
+++ b/imagefiles/build-and-install-openssl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Configure, build and install OpenSSL
 #
@@ -47,10 +47,9 @@ source $MY_DIR/utils.sh
 # copied from https://github.com/pypa/manylinux/tree/master/docker/build_scripts
 #
 
-OPENSSL_ROOT=openssl-1.0.2o
-# Hash from https://www.openssl.org/source/openssl-1.0.2o.tar.gz.sha256
-# Matches hash at https://github.com/Homebrew/homebrew-core/blob/1766321103d9780f6e38d3ac7681b8fa42cdca86/Formula/openssl.rb#L11
-OPENSSL_HASH=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
+OPENSSL_ROOT=openssl-1.0.2r
+# Hash from https://www.openssl.org/source/openssl-1.0.2r.tar.gz.sha256
+OPENSSL_HASH=ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6
 
 # XXX: the official https server at www.openssl.org cannot be reached
 # with the old versions of openssl and curl in Centos 5.11 hence the fallback

--- a/imagefiles/dockcross
+++ b/imagefiles/dockcross
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DEFAULT_DOCKCROSS_IMAGE=dockcross/base  # DO NOT MOVE THIS LINE (see entrypoint.sh)
 
@@ -178,18 +178,20 @@ UBUNTU_ON_WINDOWS=$([ -e /proc/version ] && grep -l Microsoft /proc/version || e
 MSYS=$([ -e /proc/version ] && grep -l MINGW /proc/version || echo "")
 
 if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" ]; then
-    USER_IDS="-e BUILDER_UID=$( id -u ) -e BUILDER_GID=$( id -g ) -e BUILDER_USER=$( id -un ) -e BUILDER_GROUP=$( id -gn )"
+    USER_IDS=(-e BUILDER_UID="$( id -u )" -e BUILDER_GID="$( id -g )" -e BUILDER_USER="$( id -un )" -e BUILDER_GROUP="$( id -gn )")
 fi
 
 # Change the PWD when working in Docker on Windows
 if [ -n "$UBUNTU_ON_WINDOWS" ]; then
     WSL_ROOT="/mnt/"
     CFG_FILE=/etc/wsl.conf
-    CFG_CONTENT=$(cat $CFG_FILE | sed -r '/[^=]+=[^=]+/!d' | sed -r 's/\s+=\s/=/g')
-    eval "$CFG_CONTENT"
-    if [ -n "$root" ]; then
-        WSL_ROOT=$root
-    fi
+	if [ -f "$CFG_FILE" ]; then
+		CFG_CONTENT=$(cat $CFG_FILE | sed -r '/[^=]+=[^=]+/!d' | sed -r 's/\s+=\s/=/g')
+		eval "$CFG_CONTENT"
+		if [ -n "$root" ]; then
+			WSL_ROOT=$root
+		fi
+	fi
     HOST_PWD=`pwd -P`
     HOST_PWD=${HOST_PWD/$WSL_ROOT//}
 elif [ -n "$MSYS" ]; then
@@ -218,7 +220,7 @@ CONTAINER_NAME=dockcross_$RANDOM
 docker run $TTY_ARGS --name $CONTAINER_NAME \
     -v "$HOST_PWD":/work \
     $HOST_VOLUMES \
-    $USER_IDS \
+    "${USER_IDS[@]}" \
     $FINAL_ARGS \
     $FINAL_IMAGE "$@"
 run_exit_code=$?

--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is the entrypoint script for the dockerfile. Executed in the
 # container at runtime.

--- a/imagefiles/install-cmake-binary.sh
+++ b/imagefiles/install-cmake-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 set -o pipefail

--- a/imagefiles/install-gosu-binary.sh
+++ b/imagefiles/install-gosu-binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 set -o pipefail

--- a/imagefiles/utils.sh
+++ b/imagefiles/utils.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Run the UpdateFromUpstream.sh script to extract upstream imagefiles
using the following shell commands.

$ git archive --prefix=upstream-imagefiles/ b5a13fa4 -- 
  imagefiles/build-and-install-curl.sh
  imagefiles/build-and-install-git.sh
  imagefiles/build-and-install-openssh.sh
  imagefiles/build-and-install-openssl.sh
  imagefiles/dockcross
  imagefiles/entrypoint.sh
  imagefiles/install-cmake-binary.sh
  imagefiles/install-gosu-binary.sh
  imagefiles/utils.sh
   | tar x


git://github/compare/85593886fd3ba09b1e31873f1f28c977fabf2871...b5a13fa4d2ea39fef64bb62de18ae46bf8c5d93c