### PR TITLE
Fix continuous integration marking ubuntu1004-gcc4 as deprecated

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,28 +98,6 @@ jobs:
       - save_cache:
           key: centos7-devtoolset7-gcc7-assets-{{ .Revision }}
           paths: ~/docker/centos7-devtoolset7-gcc7.tar
-  ubuntu1004-gcc4:
-    <<: *build-settings
-    steps:
-      - restore_cache:
-          keys:
-            - ubuntu1004-gcc4-assets-
-      - checkout
-      - run:
-         name: ubuntu1004-gcc4 build
-         command: |
-           docker load -i ~/docker/ubuntu1004-gcc4.tar > /dev/null 2>&1 || true
-           docker pull ubuntu:10.04
-           make ubuntu1004-gcc4
-           mkdir -p ~/docker
-           docker save -o ~/docker/ubuntu1004-gcc4.tar dockbuild/ubuntu1004-gcc4:latest dockbuild/ubuntu1004:latest
-      - run:
-         name: ubuntu1004-gcc4 test
-         command: |
-           make ubuntu1004-gcc4.test
-      - save_cache:
-          key: ubuntu1004-gcc4-assets-{{ .Revision }}
-          paths: ~/docker/ubuntu1004-gcc4.tar
   ubuntu1604-gcc5:
     <<: *build-settings
     steps:
@@ -247,15 +225,6 @@ jobs:
             docker login -u $DOCKER_USER -p $DOCKER_PASS
             docker push dockbuild/centos7-devtoolset7-gcc7:latest
       - restore_cache:
-          key: ubuntu1004-gcc4-assets-{{ .Revision }}
-      - deploy:
-          name: Deploy ubuntu1004-gcc4
-          command: |
-            docker load -i ~/docker/ubuntu1004-gcc4.tar
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker push dockbuild/ubuntu1004:latest
-            docker push dockbuild/ubuntu1004-gcc4:latest
-      - restore_cache:
           key: ubuntu1604-gcc5-assets-{{ .Revision }}
       - deploy:
           name: Deploy ubuntu1604-gcc5
@@ -304,8 +273,6 @@ workflows:
           <<: *no_filters
       - centos7-devtoolset7-gcc7:
           <<: *no_filters
-      - ubuntu1004-gcc4:
-          <<: *no_filters
       - ubuntu1604-gcc5:
           <<: *no_filters
       - ubuntu1804-gcc7:
@@ -320,7 +287,6 @@ workflows:
             - centos6-devtoolset2-gcc4
             - centos7-devtoolset4-gcc5
             - centos7-devtoolset7-gcc7
-            - ubuntu1004-gcc4
             - ubuntu1604-gcc5
             - ubuntu1804-gcc7
             - ubuntu1904-gcc8

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,11 @@ IMAGES = \
   ubuntu1904-gcc8 \
   ubuntu2004-gcc9
 
+DEPRECATED_IMAGES = \
+  ubuntu1004-gcc4
+
 # These images are built using the "build implicit rule"
-ALL_IMAGES = $(IMAGES)
+ALL_IMAGES = $(IMAGES) $(DEPRECATED_IMAGES)
 
 # On CircleCI, do not attempt to delete container
 # See https://circleci.com/docs/docker-btrfs-error/

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,7 @@ dockbuild/centos6-devtoolset2-gcc4:latest, dockbuild/centos6:latest
 dockbuild/centos7-devtoolset4-gcc5:latest, dockbuild/centos7:latest
   |centos7-devtoolset4-gcc5-latest| Centos7 based image including the `devtools-4`_.
 
+
 .. |centos7-devtoolset7-gcc7-latest| image:: https://images.microbadger.com/badges/image/dockbuild/centos7-devtoolset7-gcc7:latest.svg
   :target: https://microbadger.com/images/dockbuild/centos7-devtoolset7-gcc7:latest
 
@@ -69,13 +70,6 @@ dockbuild/centos7-devtoolset4-gcc5:latest, dockbuild/centos7:latest
 
 dockbuild/centos7-devtoolset7-gcc7:latest
   |centos7-devtoolset7-gcc7-latest| Centos7 based image including the `devtools-7`_.
-
-
-.. |ubuntu1004-gcc4-latest| image:: https://images.microbadger.com/badges/image/dockbuild/ubuntu1004-gcc4:latest.svg
-  :target: https://microbadger.com/images/dockbuild/ubuntu1004-gcc4:latest
-
-dockbuild/ubuntu1004-gcc4:latest, dockbuild/ubuntu1004:latest
-  |ubuntu1004-gcc4-latest| Ubuntu 10.04 based image.
 
 
 .. |ubuntu1604-gcc5-latest| image:: https://images.microbadger.com/badges/image/dockbuild/ubuntu1604-gcc5:latest.svg
@@ -104,6 +98,18 @@ dockbuild/ubuntu1904-gcc8:latest, dockbuild/ubuntu1904:latest
 
 dockbuild/ubuntu2004-gcc9:latest, dockbuild/ubuntu2004:latest
   |ubuntu2004-gcc9-latest| Ubuntu 20.04 based image.
+
+
+Deprecated build environments
+-----------------------------
+
+*Deprecated build environments are not built/tested/deployed using continuous integration*
+
+.. |ubuntu1004-gcc4-latest| image:: https://images.microbadger.com/badges/image/dockbuild/ubuntu1004-gcc4:latest.svg
+  :target: https://microbadger.com/images/dockbuild/ubuntu1004-gcc4:latest
+
+dockbuild/ubuntu1004-gcc4:latest, dockbuild/ubuntu1004:latest
+  |ubuntu1004-gcc4-latest| Ubuntu 10.04 based image.
 
 
 Installation


### PR DESCRIPTION
The corresponding environment is not actively maintained.