### PR TITLE
Backport podman fixes from upstream dockcross

### DIFF
--- a/imagefiles/dockcross.sh
+++ b/imagefiles/dockcross.sh
@@ -24,10 +24,10 @@ has() {
 
 # If OCI_EXE is not already set, search for a container executor (OCI stands for "Open Container Initiative")
 if [ -z "$OCI_EXE" ]; then
-    if which docker >/dev/null 2>/dev/null; then
-        OCI_EXE=docker
-    elif which podman >/dev/null 2>/dev/null; then
+    if which podman >/dev/null 2>/dev/null; then
         OCI_EXE=podman
+    elif which docker >/dev/null 2>/dev/null; then
+        OCI_EXE=docker
     else
         die "Cannot find a container executor. Search for docker and podman."
     fi
@@ -190,7 +190,7 @@ MSYS=$([ -e /proc/version ] && grep -l MINGW /proc/version || echo "")
 # CYGWIN
 CYGWIN=$([ -e /proc/version ] && grep -l CYGWIN /proc/version || echo "")
 
-if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" ]; then
+if [ -z "$UBUNTU_ON_WINDOWS" -a -z "$MSYS" -a "$OCI_EXE" != "podman" ]; then
     USER_IDS=(-e BUILDER_UID="$( id -u )" -e BUILDER_GID="$( id -g )" -e BUILDER_USER="$( id -un )" -e BUILDER_GROUP="$( id -gn )")
 fi
 


### PR DESCRIPTION
This commit backports dockcross/dockcross#689 to improve support for podman:

 - Change order of OCI  executable check (podman first; priority).
 - Avoid set user/group id as podman will run with sudo or rootless

Not having this causes permission problems when used downstream  (for reference see dockcross/dockcross#649). For instance, `SlicerBuildEnvironment` will present permission issues when configuring Slicer and will have other side effects, like changing the ownership of ~/.ssh to `16535:16535`