### PR TITLE
[Backport PR-896] fix(entrypoint.sh): Avoid error if rustup is not installed

### DIFF
--- a/imagefiles/entrypoint.sh
+++ b/imagefiles/entrypoint.sh
@@ -33,7 +33,12 @@ if [[ -n $BUILDER_UID ]] && [[ -n $BUILDER_GID ]]; then
     export HOME=/home/${BUILDER_USER}
     shopt -s dotglob
     # Move rustup/cargo directories as they are large, and not needed as root
-    mv -t $HOME/ /root/.rustup /root/.cargo
+    if [[ -d /root/.rustup ]]; then
+        mv -t $HOME/ /root/.rustup
+    fi
+    if [[ -d /root/.cargo ]]; then
+        mv -t $HOME/ /root/.cargo
+    fi
     # Copy the rest
     cp -r /root/* $HOME/
     chown -R $BUILDER_UID:$BUILDER_GID $HOME


### PR DESCRIPTION
Only move `/root/.rustup` and `/root/.cargo` directories if they exist. This prevents errors when re-using the script in environments where Rust is not installed (e.g. https://github.com/dockbuild/dockbuild).

Previously, `mv` would fail if either directory was missing:

```
mv: cannot stat '/root/.rustup': No such file or directory
mv: cannot stat '/root/.cargo': No such file or directory
```

Follow-up of:
* https://github.com/dockbuild/dockbuild/pull/85

Backport of:
* https://github.com/dockcross/dockcross/pull/896