### PR TITLE
almalinux8-devtoolset14-gcc14: Ensure the correct sudo wrapper script is used

### DIFF
--- a/almalinux8-devtoolset14-gcc14/Dockerfile.in
+++ b/almalinux8-devtoolset14-gcc14/Dockerfile.in
@@ -91,6 +91,11 @@ RUN \
   /imagefiles/build-and-install-python.sh && \
   rm -rf /imagefiles && \
   #
+  # Remove sudo provided by "devtoolset-14" since it doesn't work with
+  # our sudo wrapper calling gosu.
+  #
+  rm -f /opt/rh/gcc-toolset-14/root//usr/bin/sudo && \
+  #
   # cleanup
   #
   dnf clean all && \


### PR DESCRIPTION
Adapted from bdb416d ("centos7-devtoolset5-gcc5: Ensure the correct sudo wrapper script is used", 2018-07-29)