### PR TITLE
git: Ensure we use lf endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
This could cause issues with bash if their are Windows line endings.

Adapted from dockcross/dockcross@ce9f79e ("git: Ensure we use lf endings", 2018-08-14)