### PR TITLE
feat(almalinux8-devtoolset14-gcc14): Build and install newest libtool 2.5.3

### DIFF
--- a/almalinux8-devtoolset14-gcc14/Dockerfile.in
+++ b/almalinux8-devtoolset14-gcc14/Dockerfile.in
@@ -22,6 +22,10 @@ ARG GIT_VERSION=2.50.1
 ARG NINJA_VERSION=1.11.1.g95dee.kitware.jobserver-1
 ARG PYTHON_VERSION=3.12.11
 
+ARG LIBTOOL_ROOT=libtool-2.5.3
+ARG LIBTOOL_HASH=9322bd8f6bc848fda3e385899dd1934957169652acef716d19d19d24053abb95
+ARG LIBTOOL_DOWNLOAD_URL=http://ftp.gnu.org/gnu/libtool
+
 ARG OPENSSL_VERSION=openssl-1.1.1w
 ARG OPENSSL_HASH=cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8
 
@@ -33,6 +37,8 @@ ARG PERL_HASH=02f8c45bb379ed0c3de7514fad48c714fd46be8f0b536bfd5320050165a1ee26
 
 # Image build scripts
 COPY \
+  imagefiles/utils.sh \
+  imagefiles/build-and-install-libtool.sh \
   imagefiles/build-and-install-git.sh \
   imagefiles/build-and-install-python.sh \
   imagefiles/install-cmake-binary.sh \
@@ -87,6 +93,7 @@ RUN \
   /imagefiles/install-gosu-binary.sh && \
   /imagefiles/install-gosu-binary-wrapper.sh && \
   /imagefiles/install-ninja-binary.sh && \
+  /imagefiles/build-and-install-libtool.sh && \
   /imagefiles/build-and-install-git.sh && \
   /imagefiles/build-and-install-python.sh && \
   rm -rf /imagefiles && \

--- a/imagefiles/build-and-install-libtool.sh
+++ b/imagefiles/build-and-install-libtool.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Configure, build and install libtool
+
+set -ex
+set -o pipefail
+
+# Get script directory
+MY_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+# Get build utilities
+source $MY_DIR/utils.sh
+
+# Copied from https://github.com/pypa/manylinux/blob/70130bb463225012f71e13b7c5f8a6c69b223e56/docker/build_scripts/build_utils.sh
+function strip_ {
+    # Strip what we can -- and ignore errors, because this just attempts to strip
+    # *everything*, including non-ELF files:
+    find "$1" -type f -print0 | xargs -0 -n1 strip --strip-unneeded 2>/dev/null || true
+}
+
+# copied from https://github.com/pypa/manylinux/blob/70130bb463225012f71e13b7c5f8a6c69b223e56/docker/build_scripts/build_utils.sh
+function do_standard_install {
+    # use all flags used by ubuntu 20.04 for hardening builds, dpkg-buildflags --export
+    # other flags mentioned in https://wiki.ubuntu.com/ToolChain/CompilerFlags can't be
+    # used because the distros used here are too old
+    MANYLINUX_CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2"
+    MANYLINUX_CFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+    MANYLINUX_CXXFLAGS="-g -O2 -Wall -fdebug-prefix-map=/=. -fstack-protector-strong -Wformat -Werror=format-security"
+    MANYLINUX_LDFLAGS="-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now"
+
+    ./configure "$@" CPPFLAGS="${MANYLINUX_CPPFLAGS}" CFLAGS="${MANYLINUX_CFLAGS}" "CXXFLAGS=${MANYLINUX_CXXFLAGS}" LDFLAGS="${MANYLINUX_LDFLAGS}" > /dev/null
+    make > /dev/null
+    make install > /dev/null
+}
+
+function fetch_source {
+    local file=$1
+    check_var "${file}"
+    local url=$2
+    check_var "${url}"
+    curl --connect-timeout 30 \
+        --max-time 10 \
+        --retry 5 \
+        --retry-delay 10 \
+        --retry-max-time 30 \
+        -fsSLO ${LIBTOOL_DOWNLOAD_URL}/${LIBTOOL_ROOT}.tar.gz
+}
+
+# copied from https://github.com/pypa/manylinux/blob/70130bb463225012f71e13b7c5f8a6c69b223e56/docker/build_scripts/install-libtool.sh
+
+# Install newest libtool
+check_var "${LIBTOOL_ROOT}"
+check_var "${LIBTOOL_HASH}"
+check_var "${LIBTOOL_DOWNLOAD_URL}"
+fetch_source "${LIBTOOL_ROOT}.tar.gz" "${LIBTOOL_DOWNLOAD_URL}"
+check_sha256sum ${LIBTOOL_ROOT}.tar.gz ${LIBTOOL_HASH}
+tar -xzf ${LIBTOOL_ROOT}.tar.gz
+pushd ${LIBTOOL_ROOT}
+DESTDIR=/manylinux-rootfs do_standard_install
+popd
+rm -rf ${LIBTOOL_ROOT} ${LIBTOOL_ROOT}.tar.gz
+
+# Strip what we can
+strip_ /manylinux-rootfs
+
+# Install
+cp -rlf /manylinux-rootfs/* /
+
+# Remove temporary rootfs
+rm -rf /manylinux-rootfs/
+
+hash -r
+libtoolize --version


### PR DESCRIPTION
Adapted from https://github.com/pypa/manylinux/blob/70130bb463225012f71e13b7c5f8a6c69b223e56/docker/build_scripts/install-libtool.sh